### PR TITLE
fix: changed req.ip to use x-forwarded-for unless not available

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: Authorization microservice for medical consultation application. Handles the authorization of users for the entire application.
 
 servers:
-  - url: http://localhost:3001/api/v1
+  - url: http://localhost:3001/auth/api/v1
 
 paths:
   /users:

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -14,7 +14,7 @@ export const createUser = async (req, res) => {
         method: req.method,
         url: req.originalUrl,
         email,
-        ip: req.ip,
+        ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
       });
       return res.status(400).json({
         message: 'A user with that email already exists.',
@@ -39,7 +39,7 @@ export const createUser = async (req, res) => {
       url: req.originalUrl,
       email: newUser.email,
       userId: newUser._id.toString(),
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
 
     res.status(201).json(userWithoutPassword);
@@ -48,7 +48,7 @@ export const createUser = async (req, res) => {
       method: req.method,
       url: req.originalUrl,
       error: error.message,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(500).json({
       message: 'Internal server error.',
@@ -69,7 +69,7 @@ export const getUser = async (req, res) => {
       url: req.originalUrl,
       user: userId,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(200).json(userWithoutPassword);
   } catch (error) {
@@ -79,7 +79,7 @@ export const getUser = async (req, res) => {
       error: error.message,
       user: userId,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(500).json({ message: 'Internal server error' });
   }
@@ -100,7 +100,7 @@ export const editUser = async (req, res) => {
         method: req.method,
         url: req.originalUrl,
         email,
-        ip: req.ip,
+        ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
       });
       return res.status(400).json({
         message: 'A user with that email already exists.',
@@ -124,7 +124,7 @@ export const editUser = async (req, res) => {
       url: req.originalUrl,
       user: userId,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(200).json(userWithoutPassword);
   } catch (error) {
@@ -134,7 +134,7 @@ export const editUser = async (req, res) => {
       error: error.message,
       user: userId,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(500).json({ message: 'Internal server error' });
   }
@@ -191,7 +191,7 @@ export const deleteUser = async (req, res) => {
       url: req.originalUrl,
       user: userId,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(204).json({ _id: req.userId });
   }
@@ -202,7 +202,7 @@ export const deleteUser = async (req, res) => {
       error: error.message,
       user: userId,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     res.status(500).json({ message: 'Internal server error' });
   }
@@ -311,3 +311,4 @@ export const logout = async (req, res) => {
     }
   };
 };
+

--- a/src/controllers/validationController.js
+++ b/src/controllers/validationController.js
@@ -6,7 +6,7 @@ export const validate = async (req, res) => {
     method: req.method,
     url: req.originalUrl,
     userId: req.userId,
-    ip: req.ip,
+    ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
   });
   res.status(200).json({ message: 'Token is valid' });
 };

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -9,7 +9,7 @@ export const userExists = async (req, res, next) => {
       method: req.method,
       url: req.originalUrl,
       userId: req.userId,
-      ip: req.ip,
+      ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
     });
     return res.status(404).json({ message: 'User not found' });
   }
@@ -35,7 +35,7 @@ export const authorizeRequest = (method) => {
           method: req.method,
           url: req.originalUrl,
           userId: req.userId,
-          ip: req.ip,
+          ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
         });
         return res.status(400).json({ message: 'Invalid method' });
       }
@@ -45,7 +45,7 @@ export const authorizeRequest = (method) => {
           method: req.method,
           url: req.originalUrl,
           userId: req.userId,
-          ip: req.ip,
+          ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
         });
         return res.status(403).json({ message: 'Forbidden' });
       }
@@ -108,7 +108,7 @@ export const authorizeRequest = (method) => {
           method: req.method,
           url: req.originalUrl,
           userId: req.userId,
-          ip: req.ip,
+          ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
         });
         return res.status(403).json({ message: 'Forbidden' });
       }
@@ -119,7 +119,7 @@ export const authorizeRequest = (method) => {
         method: req.method,
         url: req.originalUrl,
         userId: req.userId,
-        ip: req.ip,
+        ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
         error: error.message,
       });
       res.status(500).json({ message: 'Internal server error' });

--- a/src/middleware/validationMiddleware.js
+++ b/src/middleware/validationMiddleware.js
@@ -24,7 +24,7 @@ export const validateToken = async (req, res, next) => {
         method: req.method,
         url: req.originalUrl,
         userId: req.userId,
-        ip: req.ip,
+        ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
       });
       return res.status(401).json({ message: 'User not found' });
     }
@@ -35,7 +35,7 @@ export const validateToken = async (req, res, next) => {
       logger.warn('Token expired', {
         method: req.method,
         url: req.originalUrl,
-        ip: req.ip,
+        ip: req.headers && req.headers['x-forwarded-for'] || req.ip,
       });
       await deleteToken(req.userId, token);
       return res.status(401).json({ message: 'Token expired' });


### PR DESCRIPTION
This pull request includes updates to the `openapi.yaml` file and several JavaScript files to enhance the logging of IP addresses by using the `x-forwarded-for` header when available. This change ensures that the correct client IP address is logged, even when the application is behind a proxy.

### Updates to IP address logging:

* [`src/controllers/userController.js`](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L17-R17): Modified multiple functions (`createUser`, `getUser`, `editUser`, `deleteUser`) to log the IP address using `req.headers['x-forwarded-for'] || req.ip`. [[1]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L17-R17) [[2]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L42-R42) [[3]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L51-R51) [[4]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L72-R72) [[5]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L82-R82) [[6]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L103-R103) [[7]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L127-R127) [[8]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L137-R137) [[9]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L194-R194) [[10]](diffhunk://#diff-6210ace6be99d7adc7dc8298a158709fef7ba29f17e9c3bd35f1f8fab8d9c8d1L205-R205)

* [`src/controllers/validationController.js`](diffhunk://#diff-642dc10ad295faab93ea9af7f02adda34b7d4fbeab6912cd948ba54439ba5eb9L9-R9): Updated the `validate` function to log the IP address using `req.headers['x-forwarded-for'] || req.ip`.

* [`src/middleware/authMiddleware.js`](diffhunk://#diff-b03519de8bc8a3860fadfeaedb79a86b62610df6361695aa44da0577523a3ea8L12-R12): Modified the `userExists` and `authorizeRequest` functions to log the IP address using `req.headers['x-forwarded-for'] || req.ip`. [[1]](diffhunk://#diff-b03519de8bc8a3860fadfeaedb79a86b62610df6361695aa44da0577523a3ea8L12-R12) [[2]](diffhunk://#diff-b03519de8bc8a3860fadfeaedb79a86b62610df6361695aa44da0577523a3ea8L38-R38) [[3]](diffhunk://#diff-b03519de8bc8a3860fadfeaedb79a86b62610df6361695aa44da0577523a3ea8L48-R48) [[4]](diffhunk://#diff-b03519de8bc8a3860fadfeaedb79a86b62610df6361695aa44da0577523a3ea8L111-R111) [[5]](diffhunk://#diff-b03519de8bc8a3860fadfeaedb79a86b62610df6361695aa44da0577523a3ea8L122-R122)

* [`src/middleware/validationMiddleware.js`](diffhunk://#diff-58b2b3a7a2db8b24b83babd38412616225ee11b15a31d35c4179ee1bac4286f3L27-R27): Updated the `validateToken` function to log the IP address using `req.headers['x-forwarded-for'] || req.ip`. [[1]](diffhunk://#diff-58b2b3a7a2db8b24b83babd38412616225ee11b15a31d35c4179ee1bac4286f3L27-R27) [[2]](diffhunk://#diff-58b2b3a7a2db8b24b83babd38412616225ee11b15a31d35c4179ee1bac4286f3L38-R38)

### Miscellaneous update:

* [`openapi.yaml`](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L8-R8): Changed the server URL to include `/auth` in the base path.