### PR TITLE
chore: updated openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: Authorization microservice for medical consultation application. Handles the authorization of users for the entire application.
 
 servers:
-  - url: http://localhost:3001/auth/api/v1
+  - url: http://localhost:3001/api/v1
 
 paths:
   /users:


### PR DESCRIPTION
This pull request includes a small change to the `openapi.yaml` file. The change updates the server URL for the authorization microservice.

* [`openapi.yaml`](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L8-R8): Changed the server URL from `http://localhost:3001/auth/api/v1` to `http://localhost:3001/api/v1`.