### PR TITLE
fix: necessary changes for production environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .env.dev
 .env.test
 .env.prod
+auth-secret.yaml
 
 # Migrations
 migrations

--- a/README.md
+++ b/README.md
@@ -99,3 +99,69 @@ docker compose up -d
 ```
 
 This command launches your deployed Docker image in detached mode.
+
+## Kubernetes Setup ☸️
+
+To run the application in Kubernetes (locally):
+
+First, install Docker.
+
+Then install kubernetes, kompose and minikube. You can see how to install them [here](https://kubernetes.io/docs/tasks/tools/).
+
+Once done, run the following commands:
+
+```bash
+minikube start
+kompose convert -o kubernetes/
+
+alias kubectl='minikube kubectl --'
+```
+
+This should create the configuration for all your services from the `docker-compose.yml` file. For ease of setup, make sure all environment variables needed are directly or indirectly defined in your `docker-compose.yaml`.
+
+Then, to create secrets for your environment variables, run:
+
+```bash
+kubectl create secret generic auth-secrets --from-env-file=.env -o yaml > kubernetes/secrets.yaml
+```
+
+Now go to your "-deployment.yaml" files and add for every secret environment variable add:
+
+```yaml
+- name: <env_var_name>
+  valueFrom:
+    secretKeyRef:
+      name: auth-secrets
+      key: <env_var_key>
+```
+
+Go to you app "-deployment.yaml" file and change the valie of the `image` field to the image you want to deploy. Most likely the lastest tag of your image on ghcr.
+
+Go to any "-service.yaml" which ports you want to expose to the open internet and add:
+
+```yaml
+  type: LoadBalancer
+  ports:
+    - protocol: <svc_protocol> # Example: TCP
+      port: <port>
+      targetPort: <port>
+      nodePort: <port_exposed> # Example: 30001
+```
+
+And then go to the other "-service.yaml" (mongodb and others) files and add the following:
+
+```yaml
+  type: ClusterIP
+  ports:
+    - protocol: <svc_protocol> # Example: TCP
+      name: "<port>"
+      port: <port>
+      targetPort: <port>
+```
+
+Then finally, to deploy your services, run:
+
+```bash
+kubectl apply -f kubernetes/
+minikube service <service_to_expose-1> <service_to_expose-2> ... <service_to_expose-n>
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,16 @@ services:
       dockerfile: Dockerfile
     container_name: authorization-svc
     environment:
-      - MONGODB_URL=${MONGOURL}
-      - API_PREFIX=${API_PREFIX}
+      - MONGOADMIN=${MONGOADMIN}
+      - MONGOPASS=${MONGOPASS}
+      - MONGOURL=${MONGOURL}
+      - DRAGONFLY_HOST=${DRAGONFLY_HOST}
+      - DRAGONFLY_PORT=6379
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION=3600
+      - JWT_REFRESH_EXPIRATION=604800
+      - KAFKA_HOST=${KAFKA_HOST}
+      - API_PREFIX=/api/v1
       - NODE_ENV=production
     depends_on:
       - mongodb

--- a/kubernetes/authorization-svc-deployment.yaml
+++ b/kubernetes/authorization-svc-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   key: MONGOURL
             - name: NODE_ENV
               value: production
-          image: ghcr.io/fis2425/authorization
+          image: ghcr.io/fis2425/authorization:PR.75
           name: authorization-svc
           ports:
             - containerPort: 3001

--- a/kubernetes/authorization-svc-deployment.yaml
+++ b/kubernetes/authorization-svc-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   key: MONGOURL
             - name: NODE_ENV
               value: production
-          image: ghcr.io/fis2425/authorization:PR.75
+          image: ghcr.io/fis2425/authorization:latest
           name: authorization-svc
           ports:
             - containerPort: 3001

--- a/kubernetes/authorization-svc-deployment.yaml
+++ b/kubernetes/authorization-svc-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: authorization-svc
+  name: authorization-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: authorization-svc
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o kubernetes/
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: authorization-svc
+    spec:
+      containers:
+        - env:
+            - name: API_PREFIX
+              value: /api/v1
+            - name: DRAGONFLY_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: DRAGONFLY_HOST
+            - name: DRAGONFLY_PORT
+              value: "6379"
+            - name: JWT_EXPIRATION
+              value: "3600"
+            - name: JWT_REFRESH_EXPIRATION
+              value: "604800"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: JWT_SECRET
+            - name: KAFKA_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: KAFKA_HOST
+            - name: MONGOADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: MONGOADMIN
+            - name: MONGOPASS
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: MONGOPASS
+            - name: MONGOURL
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: MONGOURL
+            - name: NODE_ENV
+              value: production
+          image: ghcr.io/fis2425/authorization
+          name: authorization-svc
+          ports:
+            - containerPort: 3001
+              protocol: TCP
+      restartPolicy: Always

--- a/kubernetes/authorization-svc-service.yaml
+++ b/kubernetes/authorization-svc-service.yaml
@@ -8,10 +8,11 @@ metadata:
     io.kompose.service: authorization-svc
   name: authorization-svc
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
-    - name: "3001"
+    - protocol: TCP
       port: 3001
       targetPort: 3001
+      nodePort: 30001
   selector:
     io.kompose.service: authorization-svc

--- a/kubernetes/authorization-svc-service.yaml
+++ b/kubernetes/authorization-svc-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: authorization-svc
+  name: authorization-svc
+spec:
+  type: NodePort
+  ports:
+    - name: "3001"
+      port: 3001
+      targetPort: 3001
+  selector:
+    io.kompose.service: authorization-svc

--- a/kubernetes/dragonfly-auth-persistentvolumeclaim.yaml
+++ b/kubernetes/dragonfly-auth-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: dragonfly-auth
+  name: dragonfly-auth
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/kubernetes/dragonfly-deployment.yaml
+++ b/kubernetes/dragonfly-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: dragonfly
+  name: dragonfly
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: dragonfly
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o kubernetes/
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: dragonfly
+    spec:
+      containers:
+        - image: ghcr.io/dragonflydb/dragonfly:latest
+          name: dragonfly-auth
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data/dragonfly
+              name: dragonfly-auth
+      restartPolicy: Always
+      volumes:
+        - name: dragonfly-auth
+          persistentVolumeClaim:
+            claimName: dragonfly-auth

--- a/kubernetes/dragonfly-service.yaml
+++ b/kubernetes/dragonfly-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: dragonfly
+  name: dragonfly
+spec:
+  type: NodePort
+  ports:
+    - name: "6379"
+      port: 6379
+      targetPort: 6379
+  selector:
+    io.kompose.service: dragonfly

--- a/kubernetes/dragonfly-service.yaml
+++ b/kubernetes/dragonfly-service.yaml
@@ -8,7 +8,7 @@ metadata:
     io.kompose.service: dragonfly
   name: dragonfly
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - name: "6379"
       port: 6379

--- a/kubernetes/mongo-auth-persistentvolumeclaim.yaml
+++ b/kubernetes/mongo-auth-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: mongo-auth
+  name: mongo-auth
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/kubernetes/mongodb-deployment.yaml
+++ b/kubernetes/mongodb-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o kubernetes/
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: mongodb
+    spec:
+      containers:
+        - env:
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: MONGOADMIN
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: MONGOPASS
+          image: mongo:latest
+          name: mongodb-auth
+          ports:
+            - containerPort: 27017
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongo-auth
+      restartPolicy: Always
+      volumes:
+        - name: mongo-auth
+          persistentVolumeClaim:
+            claimName: mongo-auth

--- a/kubernetes/mongodb-service.yaml
+++ b/kubernetes/mongodb-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+spec:
+  type: NodePort
+  ports:
+    - protocol: TCP
+      name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb

--- a/kubernetes/mongodb-service.yaml
+++ b/kubernetes/mongodb-service.yaml
@@ -8,7 +8,7 @@ metadata:
     io.kompose.service: mongodb
   name: mongodb
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - protocol: TCP
       name: "27017"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,6 +6,9 @@ info:
 
 servers:
   - url: http://localhost:3001/api/v1
+    description: Development server
+  - url: /api/v1
+    description: Production server
 
 paths:
   /users:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "module",
     "main": "index.js",
     "scripts": {
-        "start": "node --env-file=.env ./src/config/index.js",
+        "start": "node ./src/config/index.js",
         "lint": "eslint . --max-warnings=0 --cache --cache-location node_modules/.cache/eslint",
         "lint-fix": "eslint . --fix --max-warnings=0 --cache --cache-location node_modules/.cache/eslint",
         "dev": "node --watch --env-file=.env ./src/config/index.js",


### PR DESCRIPTION
This pull request includes significant changes to the deployment and configuration of the authorization service and related components. The changes primarily focus on transitioning to Kubernetes for deployment and updating environment variables.

### Environment Variables and Configuration:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L36-R45): Updated environment variables for the authorization service, including database credentials, JWT settings, and Kafka host information.

### Kubernetes Deployment:
* [`kubernetes/authorization-svc-deployment.yaml`](diffhunk://#diff-3bfe2c23761f3bb83f4ba93dc07afe65fb93fe55b72fa7bc21b954ca9ff8adbaR1-R70): Added a new deployment configuration for the authorization service, including environment variables and container settings.
* [`kubernetes/authorization-svc-service.yaml`](diffhunk://#diff-483a386afb8d47f82dc0e41482defb22bfb4d16ed8354f5abab426e5826a02c9R1-R17): Created a new service configuration for the authorization service to expose it via NodePort.
* [`kubernetes/dragonfly-deployment.yaml`](diffhunk://#diff-83cc55f3405d51ce37238b865edcf491007277b652d13d5db1d2880dce551c72R1-R38): Added a deployment configuration for the Dragonfly service, including container settings and volume mounts.
* [`kubernetes/dragonfly-service.yaml`](diffhunk://#diff-bc7bd13865ee42f4eacf494c2d1120210b35ba30828a704223986b94f6b4472eR1-R17): Created a new service configuration for the Dragonfly service to expose it via NodePort.
* [`kubernetes/mongodb-deployment.yaml`](diffhunk://#diff-37303c2921f0256f198ee864e1b2ca069f8e3485b6a6513a627c5c3e870f0d00R1-R49): Added a deployment configuration for MongoDB, including environment variables and volume mounts.
* [`kubernetes/mongodb-service.yaml`](diffhunk://#diff-4094af2a5f5058f456d8d49437f645bf8f1abef40bcb804acc4425cd742a9600R1-R18): Created a new service configuration for MongoDB to expose it via NodePort.

### Persistent Volume Claims:
* [`kubernetes/dragonfly-auth-persistentvolumeclaim.yaml`](diffhunk://#diff-841feed3b5d966478e408b25c67358580f87ce4af4655aebe0ea9c2c0e38fb30R1-R12): Added a persistent volume claim for the Dragonfly service.
* [`kubernetes/mongo-auth-persistentvolumeclaim.yaml`](diffhunk://#diff-6877040337a597b68ce911295be5d916dbf2e22943f7d99588c34eb062a28d64R1-R12): Added a persistent volume claim for MongoDB.

### Miscellaneous:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14): Updated the `start` script to remove the `--env-file` option.