### PR TITLE
fix: added dev cookie and secure cookie to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       - KAFKA_HOST=${KAFKA_HOST}
       - API_PREFIX=/api/v1
       - NODE_ENV=production
+      - SECURE_COOKIE=${SECURE_COOKIE}
+      - DEV_COOKIE=${DEV_COOKIE}
     depends_on:
       - mongodb
       - dragonfly


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change adds two new environment variables, `SECURE_COOKIE` and `DEV_COOKIE`, to the `services:` section.

Changes in `services:`:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R45-R46): Added `SECURE_COOKIE` and `DEV_COOKIE` environment variables.